### PR TITLE
security: Fix RUSTSEC-2024-0370 proc-macro-error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,4 @@ proc-macro = true
 syn = { version = "1.0.72", features = ["full"] }
 quote = "1.0.9"
 proc-macro2 = "1.0.26"
-proc-macro-error = "1.0.4"
-
+proc-macro-error2 = "2.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use {
     syn::LitStr,
     proc_macro::TokenStream,
     quote::quote,
-    proc_macro_error::{abort, proc_macro_error},
+    proc_macro_error2::{abort, proc_macro_error},
 };
 
 #[proc_macro_error]


### PR DESCRIPTION
proc-macro-error is unmaintained. Replaced with API-compatible proc-macro-error2.

Could we get a new release with this? :-)